### PR TITLE
Add Jest tests for utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",

--- a/src/utils/__tests__/common.test.js
+++ b/src/utils/__tests__/common.test.js
@@ -1,0 +1,15 @@
+const path = require('path');
+const modulePath = path.resolve(__dirname, '..', 'common.js');
+
+describe('common utils', () => {
+  test('getRoomId returns same id regardless of order', async () => {
+    const { getRoomId } = await import(modulePath);
+    expect(getRoomId('user1', 'user2')).toBe(getRoomId('user2', 'user1'));
+  });
+
+  test('formatDate formats date as "day Mon"', async () => {
+    const { formatDate } = await import(modulePath);
+    const date = new Date(2024, 0, 5); // 5 Jan 2024
+    expect(formatDate(date)).toBe('5 Jan');
+  });
+});


### PR DESCRIPTION
## Summary
- add `test` npm script
- create Jest test for `getRoomId` and `formatDate`

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_6850e5ca85f4832bb30f686efb6c6a6c